### PR TITLE
feat: support hyper edge improver in wasm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.vscode

--- a/cola/libavoid/connectionpin.h
+++ b/cola/libavoid/connectionpin.h
@@ -242,6 +242,9 @@ class AVOID_EXPORT ShapeConnectionPin
         //!
         bool isExclusive(void) const;
 
+        void updateRelativePosition(const Point& newPosition);
+        void updateVisibility(ConnDirFlags visDirs);
+
         ConnectionPinIds ids(void) const;
 
         bool operator==(const ShapeConnectionPin& rhs) const;
@@ -254,6 +257,7 @@ class AVOID_EXPORT ShapeConnectionPin
         friend class Router;
  
         void commonInitForShapeConnection(void);
+        void checkOffset(void);
         void updatePosition(const Point& newPosition);
         void updatePosition(const Polygon& newPoly);
         void updatePositionAndVisibility(void);

--- a/cola/libavoid/connector.cpp
+++ b/cola/libavoid/connector.cpp
@@ -516,6 +516,18 @@ std::pair<ConnEnd, ConnEnd> ConnRef::endpointConnEnds(void) const
     return endpoints;
 }
 
+ConnEnd ConnRef::getSourceEndpoint(void) const 
+{
+    std::pair<ConnEnd, ConnEnd> endpoints = endpointConnEnds();
+    return endpoints.first;
+}
+
+ConnEnd ConnRef::getDestEndpoint(void) const 
+{
+    std::pair<ConnEnd, ConnEnd> endpoints = endpointConnEnds();
+    return endpoints.second;
+}
+
 bool ConnRef::setEndpoint(const unsigned int type, const VertID& pointID,
         Point *pointSuggestion)
 {

--- a/cola/libavoid/connector.h
+++ b/cola/libavoid/connector.h
@@ -339,6 +339,9 @@ class AVOID_EXPORT ConnRef
         //!
         std::pair<ConnEnd, ConnEnd> endpointConnEnds(void) const;
 
+        ConnEnd getSourceEndpoint(void) const;
+        ConnEnd getDestEndpoint(void) const;
+
         // @brief   Returns the source endpoint vertex in the visibility graph.
         // @returns The source endpoint vertex.
         VertInf *src(void) const;

--- a/cola/libavoid/hyperedge.cpp
+++ b/cola/libavoid/hyperedge.cpp
@@ -57,6 +57,13 @@ size_t HyperedgeRerouter::registerHyperedgeForRerouting(
     return m_terminals_vector.size() - 1;
 }
 
+size_t HyperedgeRerouter::registerHyperedgeForReroutingViaVector(
+        ConnEndVector terminals)
+{
+    ConnEndList terminal_list(terminals.begin(), terminals.end());
+    return registerHyperedgeForRerouting(terminal_list);
+}
+
 size_t HyperedgeRerouter::registerHyperedgeForRerouting(
         JunctionRef *junction)
 {
@@ -82,6 +89,30 @@ HyperedgeNewAndDeletedObjectLists HyperedgeRerouter::newAndDeletedObjectLists(
     result.deletedJunctionList = m_deleted_junctions_vector[index];
     result.newConnectorList = m_new_connectors_vector[index];
     result.deletedConnectorList = m_deleted_connectors_vector[index];
+
+    return result;
+}
+
+HyperedgeNewAndDeletedObjects HyperedgeRerouter::newAndDeletedObjects(
+        size_t index) const
+{
+    HyperedgeNewAndDeletedObjects result;
+
+    HyperedgeNewAndDeletedObjectLists result_lists = newAndDeletedObjectLists(index);
+    JunctionRefVector new_junctions{ std::begin(result_lists.newJunctionList), std::end(result_lists.newJunctionList) };
+    JunctionRefVector deleted_junctions{ std::begin(result_lists.deletedJunctionList), std::end(result_lists.deletedJunctionList) };
+    ConnRefVector new_connectors{ std::begin(result_lists.newConnectorList), std::end(result_lists.newConnectorList) };
+    ConnRefVector deleted_connectors{ std::begin(result_lists.deletedConnectorList), std::end(result_lists.deletedConnectorList) };
+
+    result.newJunctions = new_junctions;
+    result.numberOfNewJunctions = new_junctions.size();
+    result.deletedJunctions = deleted_junctions;
+    result.numberOfDeletedJunctions = deleted_junctions.size();
+    result.newConnectors = new_connectors;
+    result.numberOfNewConnectors = new_connectors.size();
+    result.deletedConnectors = deleted_connectors;
+    result.numberOfDeletedConnectors = deleted_connectors.size();
+    result.numberOfChangedConnectors = 0;
 
     return result;
 }

--- a/cola/libavoid/hyperedge.h
+++ b/cola/libavoid/hyperedge.h
@@ -45,9 +45,11 @@ class VertInf;
 
 //! @brief   A list of ConnEnd objects.
 typedef std::list<ConnEnd> ConnEndList;
+typedef std::vector<ConnEnd> ConnEndVector;
 
 //! @brief   A list of ConnRef objects.
 typedef std::list<ConnRef *> ConnRefList;
+typedef std::vector<ConnRef *> ConnRefVector;
 
 //! @brief   A list of JunctionRef objects.
 typedef std::list<JunctionRef *> JunctionRefList;
@@ -92,6 +94,34 @@ struct HyperedgeNewAndDeletedObjectLists
         
         //! A list of changed connectors.
         ConnRefList      changedConnectorList;
+};
+
+struct HyperedgeNewAndDeletedObjects
+{
+        //! A list of newly created junctions.
+        JunctionRefVector newJunctions;
+
+        size_t numberOfNewJunctions;
+
+        //! A list of newly created connectors.
+        ConnRefVector newConnectors;
+
+        size_t numberOfNewConnectors;
+        
+        //! A list of deleted junctions.
+        JunctionRefVector  deletedJunctions;
+
+        size_t numberOfDeletedJunctions;
+
+        //! A list of deleted connectors.
+        ConnRefVector deletedConnectors;
+
+        size_t numberOfDeletedConnectors;
+        
+        //! A list of changed connectors.
+        ConnRefVector changedConnectors;
+
+        size_t numberOfChangedConnectors;
 };
 
 
@@ -146,6 +176,7 @@ class AVOID_EXPORT HyperedgeRerouter
         //!         resulting routing of the hyperedge.
         //!
         size_t registerHyperedgeForRerouting(ConnEndList terminals);
+        size_t registerHyperedgeForReroutingViaVector(ConnEndVector terminals);
 
         //! @brief  Registers a hyperedge to be fully rerouted the next time
         //!         the router processes a transaction.
@@ -180,6 +211,9 @@ class AVOID_EXPORT HyperedgeRerouter
         //!         junctions and connectors created and deleted.
         //!
         HyperedgeNewAndDeletedObjectLists newAndDeletedObjectLists(
+                size_t index) const;
+
+        HyperedgeNewAndDeletedObjects newAndDeletedObjects(
                 size_t index) const;
 
         // @brief  The number of hyperedges that are being or have been

--- a/cola/libavoid/hyperedgeimprover.cpp
+++ b/cola/libavoid/hyperedgeimprover.cpp
@@ -1036,6 +1036,31 @@ HyperedgeNewAndDeletedObjectLists
 
     return result;
 }
+HyperedgeNewAndDeletedObjects
+        HyperedgeImprover::newAndDeletedObjects(void) const
+{
+    HyperedgeNewAndDeletedObjects result;
+    HyperedgeNewAndDeletedObjectLists result_lists = newAndDeletedObjectLists();
+
+    JunctionRefVector new_junctions{ std::begin(result_lists.newJunctionList), std::end(result_lists.newJunctionList) };
+    JunctionRefVector deleted_junctions{ std::begin(result_lists.deletedJunctionList), std::end(result_lists.deletedJunctionList) };
+    ConnRefVector new_connectors{ std::begin(result_lists.newConnectorList), std::end(result_lists.newConnectorList) };
+    ConnRefVector deleted_connectors{ std::begin(result_lists.deletedConnectorList), std::end(result_lists.deletedConnectorList) };
+    ConnRefVector changed_connectors{ std::begin(result_lists.changedConnectorList), std::end(result_lists.changedConnectorList) };
+
+    result.newJunctions = new_junctions;
+    result.numberOfNewJunctions = new_junctions.size();
+    result.deletedJunctions = deleted_junctions;
+    result.numberOfDeletedJunctions = deleted_junctions.size();
+    result.newConnectors = new_connectors;
+    result.numberOfNewConnectors = new_connectors.size();
+    result.deletedConnectors = deleted_connectors;
+    result.numberOfDeletedConnectors = deleted_connectors.size();
+    result.changedConnectors = changed_connectors;
+    result.numberOfNewConnectors = changed_connectors.size();
+
+    return result;
+}
 
 
 // This method moves the junction at the given node along any shared paths

--- a/cola/libavoid/hyperedgeimprover.h
+++ b/cola/libavoid/hyperedgeimprover.h
@@ -34,6 +34,7 @@ namespace Avoid {
 
 struct HyperedgeTreeNode;
 struct HyperedgeTreeEdge;
+struct HyperedgeNewAndDeletedObjects;
 class HyperedgeShiftSegment;
 class ConnRef;
 class JunctionRef;
@@ -62,6 +63,7 @@ public:
     // Returns lists of junctions and connectors created and deleted during 
     // hyperedge improvement.
     HyperedgeNewAndDeletedObjectLists newAndDeletedObjectLists(void) const;
+    HyperedgeNewAndDeletedObjects newAndDeletedObjects(void) const;
 
     // Execute local improvement process.
     void execute(bool canMakeMajorChanges);

--- a/cola/libavoid/router.cpp
+++ b/cola/libavoid/router.cpp
@@ -3114,6 +3114,11 @@ HyperedgeNewAndDeletedObjectLists
 {
     return m_hyperedge_improver.newAndDeletedObjectLists();
 }
+HyperedgeNewAndDeletedObjects 
+        Router::newAndDeletedObjectsFromHyperedgeImprovement(void) const
+{
+    return m_hyperedge_improver.newAndDeletedObjects();
+}
 
 
 ConnRerouteFlagDelegate::ConnRerouteFlagDelegate()

--- a/cola/libavoid/router.h
+++ b/cola/libavoid/router.h
@@ -761,6 +761,8 @@ class AVOID_EXPORT Router {
         //!
         HyperedgeNewAndDeletedObjectLists 
                 newAndDeletedObjectListsFromHyperedgeImprovement(void) const;
+        HyperedgeNewAndDeletedObjects 
+                newAndDeletedObjectsFromHyperedgeImprovement(void) const;
 
         void setDebugHandler(DebugHandler *handler);
         DebugHandler *debugHandler(void) const;


### PR DESCRIPTION
Webidl doesn't support std::list right away. Hence, I transformed them to std::vector. This commit also allows to update the port position relative to the component.