### PR TITLE
fix: make inactive only when active

### DIFF
--- a/cola/libavoid/router.cpp
+++ b/cola/libavoid/router.cpp
@@ -549,7 +549,9 @@ void Router::processActions(void)
         // XXX: We don't really need to do this if we're not using Partial
         //      Feedback.  Without this the blocked edges still route
         //      around the shape until it leaves the connector.
-        obstacle->makeInactive();
+        if (obstacle->isActive()) {
+            obstacle->makeInactive();
+        }
 
         if (!isMove)
         {


### PR DESCRIPTION
Sometimes there is an error thrown when obstacle is marked as inactive, but actually it is inactive. This commit fixes the issue.